### PR TITLE
Miscellaneous testing improvements

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,3 +1,0 @@
-[mypy]
-ignore_missing_imports = True
-show_error_codes = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,3 +17,7 @@ line_length = 100
 force_sort_within_sections = true
 # Combines "as" imports on the same line
 combine_as_imports = true
+
+[tool.mypy]
+ignore_missing_imports = true
+show_error_codes = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,13 +2,6 @@ import pytest
 
 from retryable_requests import RetryableSession
 
-LISTEN_PORT = 6749
-
-
-@pytest.fixture(scope='session')
-def httpserver_listen_address():
-    return 'localhost', LISTEN_PORT
-
 
 @pytest.fixture
 def session():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,15 +11,5 @@ def httpserver_listen_address():
 
 
 @pytest.fixture
-def base_url(httpserver_listen_address):
-    return f'http://{httpserver_listen_address[0]}:{httpserver_listen_address[1]}'
-
-
-@pytest.fixture
-def base_url_session(base_url):
-    return RetryableSession(base_url)
-
-
-@pytest.fixture
 def session():
     return RetryableSession()

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -37,7 +37,7 @@ def test_session_base_url_retries_bad_status_codes(httpserver, fails_first_time)
 def test_session_retries_connection_errors(session, mocker, protocol):
     spy = mocker.spy(HTTPConnectionPool, 'urlopen')
     with pytest.raises(ConnectionError):
-        session.get(f'{protocol}://some-bad-connection.dev')
+        session.get(f'{protocol}://some-bad-connection.invalid')
 
     # the initial request + the number of total retries
     assert spy.call_count == 1 + DEFAULT_RETRY_STRATEGY.total

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -24,9 +24,9 @@ def test_base_url_session_retries_bad_status_codes(httpserver, base_url_session,
     assert r.ok, r.text
 
 
-def test_session_retries_bad_status_codes(httpserver, base_url, session, fails_first_time):
+def test_session_retries_bad_status_codes(httpserver, session, fails_first_time):
     httpserver.expect_request('/').respond_with_handler(fails_first_time)
-    r = session.get(f'{base_url}/')
+    r = session.get(httpserver.url_for('/'))
     assert r.ok, r.text
 
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,3 +1,5 @@
+from itertools import chain, repeat
+
 import pytest
 from requests.exceptions import ConnectionError
 from urllib3.connectionpool import HTTPConnectionPool
@@ -6,24 +8,23 @@ from werkzeug.wrappers import Response
 from retryable_requests.session import DEFAULT_RETRY_STRATEGY
 
 
-def fails_first_time(request):
-    if fails_first_time.responded:
-        return Response({}, 200)
-    else:
-        fails_first_time.responded = True
-        return Response({}, 500)
+@pytest.fixture
+def fails_first_time(mocker):
+    return mocker.Mock(
+        side_effect=chain(
+            [Response({}, 500)],
+            repeat(Response({}, 200)),
+        )
+    )
 
 
-fails_first_time.responded = False  # type: ignore
-
-
-def test_base_url_session_retries_bad_status_codes(httpserver, base_url_session):
+def test_base_url_session_retries_bad_status_codes(httpserver, base_url_session, fails_first_time):
     httpserver.expect_request('/', method='GET').respond_with_handler(fails_first_time)
     r = base_url_session.get('/')
     assert r.ok, r.text
 
 
-def test_session_retries_bad_status_codes(httpserver, base_url, session):
+def test_session_retries_bad_status_codes(httpserver, base_url, session, fails_first_time):
     httpserver.expect_request('/', method='GET').respond_with_handler(fails_first_time)
     r = session.get(f'{base_url}/')
     assert r.ok, r.text

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -19,13 +19,13 @@ def fails_first_time(mocker):
 
 
 def test_base_url_session_retries_bad_status_codes(httpserver, base_url_session, fails_first_time):
-    httpserver.expect_request('/', method='GET').respond_with_handler(fails_first_time)
+    httpserver.expect_request('/').respond_with_handler(fails_first_time)
     r = base_url_session.get('/')
     assert r.ok, r.text
 
 
 def test_session_retries_bad_status_codes(httpserver, base_url, session, fails_first_time):
-    httpserver.expect_request('/', method='GET').respond_with_handler(fails_first_time)
+    httpserver.expect_request('/').respond_with_handler(fails_first_time)
     r = session.get(f'{base_url}/')
     assert r.ok, r.text
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -5,7 +5,7 @@ from requests.exceptions import ConnectionError
 from urllib3.connectionpool import HTTPConnectionPool
 from werkzeug.wrappers import Response
 
-from retryable_requests.session import DEFAULT_RETRY_STRATEGY
+from retryable_requests.session import DEFAULT_RETRY_STRATEGY, RetryableSession
 
 
 @pytest.fixture
@@ -18,15 +18,18 @@ def fails_first_time(mocker):
     )
 
 
-def test_base_url_session_retries_bad_status_codes(httpserver, base_url_session, fails_first_time):
-    httpserver.expect_request('/').respond_with_handler(fails_first_time)
-    r = base_url_session.get('/')
-    assert r.ok, r.text
-
-
 def test_session_retries_bad_status_codes(httpserver, session, fails_first_time):
     httpserver.expect_request('/').respond_with_handler(fails_first_time)
     r = session.get(httpserver.url_for('/'))
+    assert r.ok, r.text
+
+
+def test_session_base_url_retries_bad_status_codes(httpserver, fails_first_time):
+    httpserver.expect_request('/base/stem').respond_with_handler(fails_first_time)
+    session = RetryableSession(base_url=httpserver.url_for('/base/'))
+
+    r = session.get('stem')
+
     assert r.ok, r.text
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -32,8 +32,8 @@ commands =
 skipsdist = true
 skip_install = true
 deps =
-     types-requests
-     mypy
+    types-requests
+    mypy
 commands =
     mypy {posargs:.}
 

--- a/tox.ini
+++ b/tox.ini
@@ -74,3 +74,6 @@ ignore =
     W503,
     # Missing docstring in *
     D10,
+
+[pytest]
+addopts = --strict-markers --showlocals --verbose


### PR DESCRIPTION
* Make `fails_first_time` reset state between test cases
* Remove unnecessary specificity from expect_request matching
* Use pytest-httpserver utility to build URLs
* Test that `base_url` joining works properly, in addition to retrying
* Use an [RFC 2606](https://datatracker.ietf.org/doc/html/rfc2606) invalid TLD, instead of one which can resolve
* Add helpful pytest default options
* Fix `tox.ini` formatting
* Allow pytest-httpserver to choose its own port
* Include mypy config in `pyproject.toml`